### PR TITLE
feat: Makefile for verilog only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt update \
     && apt install -y \
         python3=3.9.2-3 \
         python3-pip=20.3.4-4+deb11u1 \
-        ghdl=1.0.0+dfsg-3 \
+        iverilog=11.0-1 \
         gtkwave=3.3.104-2 \
     && apt clean
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,22 @@ RUN apt update \
         python3-pip=20.3.4-4+deb11u1 \
         iverilog=11.0-1 \
         gtkwave=3.3.104-2 \
+        wget \
     && apt clean
+
+# Install verible
+
+ENV VERIBLE_VERSION="v0.0-3351-g92dc6261"
+ENV VERIBLE_TARBALL="verible-${VERIBLE_VERSION}-linux-static-x86_64.tar.gz"
+ENV VERIBLE_DIR="verible-${VERIBLE_VERSION}"
+
+RUN wget --progress=dot:giga "https://github.com/chipsalliance/verible/releases/download/${VERIBLE_VERSION}/${VERIBLE_TARBALL}" \
+    && tar -xf ${VERIBLE_TARBALL} \
+    && install ${VERIBLE_DIR}/bin/* /usr/local/bin/ \
+    && rm -rf "${VERIBLE_DIR}" "${VERIBLE_TARBALL}" \
+    && verible-verilog-format --version
+
+# Install python requirements
 
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,14 @@ help:  ## Shows the available targets
 	@grep -E '^[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 
+clean:  ## Clean building files
+	@$(call run_in_container, find . \
+		-name 'results.xml' -o \
+		-name 'sim.vpp' -o \
+		-name 'waveform.vcd' \
+		-exec rm -r {} \;)
+
+
 build-docker:  ## Build the docker used for development
 	docker build --no-cache --tag ${DOCKER_IMAGE_NAME} -f Dockerfile .
 
@@ -47,4 +55,4 @@ quality: flake8 verible  ## Run all quality check
 
 
 .DEFAULT_GOAL := help
-.PHONY: help build-docker dockershell test flake8 verible quality
+.PHONY: help clean build-docker dockershell test flake8 verible quality

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ define run_in_container
 		-v /var/run/dbus:/var/run/dbus \
 		--network host \
 		-e DISPLAY=$(DISPLAY) \
-		-e GUI=$(GUI) \
 		${EXTRA_ARGS} \
 		-v $(PWD):/code -w /code \
 		$(DOCKER_IMAGE_NAME) $(1)
@@ -18,7 +17,7 @@ help:  ## Shows the available targets
 
 
 build-docker:  ## Build the docker used for development
-	docker build --tag ${DOCKER_IMAGE_NAME} -f Dockerfile .
+	docker build --no-cache --tag ${DOCKER_IMAGE_NAME} -f Dockerfile .
 
 
 dockershell:  ## Run the development container
@@ -31,22 +30,21 @@ test:  ## Run all tests or the ones for specific module setting DUT variable
 
 waves:  ## Run gtkwave with last test waves from DUT variable
 	@[ "${DUT}" ] || ( echo "Usage:    DUT=<module> make waves"; exit 1 )
-	$(eval GUI=1)
-	@$(call run_in_container, ./run_cocotb_tests.sh ${DUT})
+	@$(call run_in_container, ./run_cocotb_tests.sh ${DUT} --waves)
 
 
 flake8:  ## Run flake8 code quality check
 	$(eval PYTHON_FILES := $(shell find . -name "*.py"))
-	@$(call run_in_container, flake8 ${PYTHON_FILES})
+	@$(call run_in_container, flake8 ${PYTHON_FILES} --max-line-length=120)
 
 
-vsg:  ## Run vhdl-style-guide code quality check
-	$(eval VHDL_FILES := $(shell find rtl/ -name "*.vhd"))
-	@$(call run_in_container, vsg -f ${VHDL_FILES})
+verible:  ## Run verible-verilog-lint code quality check
+	$(eval VHDL_FILES := $(shell find rtl/ -name "*.v"))
+	@$(call run_in_container, verible-verilog-lint ${VHDL_FILES})
 
 
-quality: flake8 vsg  ## Run all quality check
+quality: flake8 verible  ## Run all quality check
 
 
 .DEFAULT_GOAL := help
-.PHONY: help build-docker dockershell test flake8 vsg quality
+.PHONY: help build-docker dockershell test flake8 verible quality

--- a/icarus.cf
+++ b/icarus.cf
@@ -1,0 +1,1 @@
++timescale+1ns/1ps

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-cocotb==1.7.2
+cocotb==1.8.0
 flake8==6.0.0
-vsg==3.15.0

--- a/run_cocotb_tests.sh
+++ b/run_cocotb_tests.sh
@@ -1,35 +1,12 @@
 #!/bin/bash
 
-RTL_PATH="rtl/"
-COCOTB_MAKEFILE_TEMPLATE='Makefile.cocotb-template'
+if [ ! -z $1 ]; then
+    DUT="--dut $1"
+fi
 
-run_test() {
-    module=$1
-    module_directory=$2
+if [ ! -z $2 ]; then
+    WAVES="--waves"
+fi
 
-    echo "Testing $DUT"
-
-    eval "echo \"$(cat $COCOTB_MAKEFILE_TEMPLATE)\"" > $module_directory/Makefile
-
-    make -C $module_directory sim
-
-    rm $module_directory/Makefile
-}
-
-
-
-DUT=${1:-*}
-
-for dut_path in $(find $RTL_PATH -name "test_$DUT.py")
-do
-    DUT=$(echo $dut_path | sed -E "s#^.+test_([a-zA-Z0-9_.-]+)\.py\$#\1#")
-
-    # TODO: Si mantenemos nombres unicos para cada modulo, podriamos dejarlos en tests/
-    dut_directory=${dut_path%%/test_$DUT.py}
-
-    run_test $DUT $dut_directory
-
-    if [ ! -z "${GUI}" ]; then
-        gtkwave $module_directory/*.vcd
-    fi
-done
+export PYTHONPATH=tests/
+python3 run_tests.py $DUT $WAVES

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,131 @@
+import argparse
+import logging
+import os
+import subprocess
+
+from cocotb.runner import get_runner
+from tempfile import TemporaryDirectory
+
+
+# Build and test configs
+HDL_LANGUAGE = 'verilog'
+VERILOG_SIM_DEFAULT = 'icarus'
+VERILOG_GPI_INTERFACES = ["vpi"]
+TESTS_DIRECTORY = 'tests'
+MODULES_DIRECTORY = 'rtl'
+ICARUS_CFG_FILE = 'icarus.cf'
+
+# Verilog directives to dump the test result in a vcd waveform file
+VERILOG_DUMP_CONFIG_FILE = 'verilog_dump.v'
+MODULE_PLACEHOLDER = 'REPLACE_WITH_MODULE_NAME'
+WAVEFORM_FILE = 'waveform.vcd'
+
+sim = os.getenv('SIM', VERILOG_SIM_DEFAULT)
+logger = logging.getLogger(name='run_tests')
+
+
+def get_testable_modules():
+    """ Get all testable modules
+
+        Return a list of tuples with (module, module_path, test_path)
+    """
+    modules = {}
+
+    for dirpath, dirnames, filenames in os.walk(MODULES_DIRECTORY):
+        for file in filenames:
+            if file.endswith('.v'):
+                modules[file.removesuffix('.v')] = os.path.join(dirpath, file)
+
+    testable_modules = []
+
+    for dirpath, dirnames, filenames in os.walk(TESTS_DIRECTORY):
+        for file in filenames:
+            if file.startswith('test_') and file.endswith('.py'):
+                module = file.removeprefix('test_').removesuffix('.py')
+                module_path = modules.get(module)
+                if module_path:
+                    test_path = os.path.join(dirpath, file)
+                    testable_modules.append((module, module_path, test_path))
+
+    return testable_modules
+
+
+def config_waveform_dump(tmp_dir, module):
+    """ Generates a temporary config file to dump a waveform file
+
+        Returns a the tmp configuration file path
+    """
+
+    with open(VERILOG_DUMP_CONFIG_FILE, 'r') as file:
+        filedata = file.read()
+
+    filedata = filedata.replace(MODULE_PLACEHOLDER, module)
+
+    tmp_conf = os.path.join(tmp_dir, VERILOG_DUMP_CONFIG_FILE)
+
+    with open(tmp_conf, 'w+') as file:
+        file.write(filedata)
+
+    return tmp_conf
+
+
+def test_cocotb(dut, waves=False):
+
+    runner = get_runner(sim)
+
+    testeable_modules = get_testable_modules()
+
+    if dut:
+        modules = [mod for mod in testeable_modules if mod[0] == dut]
+
+        if modules == []:
+            logger.error(f'Missing DUT {dut}')
+            return 1
+    else:
+        modules = testeable_modules
+
+    for module, module_path, test_path in modules:
+
+        with TemporaryDirectory() as tmp_dir:
+
+            module_dir = module_path.removesuffix(f'{module}.v')
+
+            runner.build(
+                verilog_sources=[module_path, config_waveform_dump(tmp_dir, module)],
+                hdl_toplevel=module,
+                build_dir=module_dir,
+                build_args=["-f", os.path.abspath(ICARUS_CFG_FILE)],
+            )
+
+            runner.test(
+                hdl_toplevel_lang=HDL_LANGUAGE,
+                hdl_toplevel=module,
+                test_module=f"test_{module}",
+                gpi_interfaces=VERILOG_GPI_INTERFACES,
+                build_dir=module_dir,
+                test_dir=module_dir,
+                plusargs=['-f', os.path.abspath(ICARUS_CFG_FILE)],
+                waves=True,
+            )
+
+        if dut and waves:
+            waveform = os.path.join(module_dir, WAVEFORM_FILE)
+            subprocess.run(['gtkwave', waveform])
+
+
+def parse_args():
+    p = argparse.ArgumentParser(prog='tun_tests.py',
+                                description='Helper to run tests')
+
+    p.add_argument('--dut', help='Run test for one DUT')
+
+    dut = p.add_argument_group('dut')
+    dut.add_argument('-w', '--waves', action='store_true', help='Open waveforms for ')
+
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    test_cocotb(args.dut, args.waves)

--- a/verilog_dump.v
+++ b/verilog_dump.v
@@ -1,0 +1,6 @@
+module cocotb_icarus_dump();
+initial begin
+    $dumpfile("waveform.vcd");
+    $dumpvars(0, REPLACE_WITH_MODULE_NAME);
+end
+endmodule


### PR DESCRIPTION
# Descripcion

Actualizo `Makefile` con los siguientes targets:

```
$ make
build-docker         Build the docker used for development
clean                Clean building files
dockershell          Run the development container
flake8               Run flake8 code quality check
help                 Shows the available targets
quality              Run all quality check
test                 Run all tests or the ones for specific module setting DUT variable
verible              Run verible-verilog-lint code quality check
waves                Run gtkwave with last test waves from DUT variable
```

## Implementacion

Reemplazo herramientas uso de `vhdl` por `verilog`.
- Compilador `ghdl` -> `iverilog`
- Linter `vsg` -> `verible`

Ejecución de tests mediante `run_test.py` usando `cocotb` runner con sources de `verilog`.

### Flujo de trabajo propuesto

Setup:

1. `make build` construye la imagen de docker (cada vez que se modifique el archivo `Dockerfile`, no es necesario si no hubo cambios)

Desarrollo del core y/o tests respetando la siguiente estructura:

```
rtl/<directory1>/<directory2>
└──  <module>.v
tests/
└── test_<module>.py
```

1. `make flake8` chequea estilo de codigo python (los tests)
2. `make verible` chequea estilo de codigo verilog
3. `make test` corre todos los tests y `DUT=<module> make test` solo corre los tests del archivo llamado `test_<module>.py`
4. `DUT=<module> make waves` corre tests de un modulo y abre `gtkwave` con el waveform de salida

> Cada paso puede ejecutarse de forma manual dentro de un container que use la imagen de docker. Para ello el target `make dockershell` ejecuta `bash` en modo interactivo.

## Requisitos

- [docker](https://docs.docker.com/engine/install/) instalado

## Posibles problemas

Si `make waves` devuelve error al tratar de abrir `gtkwave` puede deberse a un problema de conexion a `xhost`.

## Referencias

- [cocotb](https://docs.cocotb.org/en/stable/install.html)
- [flake8](https://flake8.pycqa.org/en/latest/)
- [Makefile help](https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html)

# Proximos pasos

Pueden realizarse cambios en la estructura del proyecto como asi tambien en la forma de ejecutar tests.