### PR TITLE
feat: Add spi_slave core

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ clean:  ## Clean building files
 		-exec rm -r {} \;)
 
 
-build-docker:  ## Build the docker used for development
+build.docker:  ## Build the docker used for development
 	docker build --no-cache --tag ${DOCKER_IMAGE_NAME} -f Dockerfile .
 
 
@@ -36,9 +36,14 @@ test:  ## Run all tests or the ones for specific module setting DUT variable
 	@$(call run_in_container, ./run_cocotb_tests.sh ${DUT})
 
 
-waves:  ## Run gtkwave with last test waves from DUT variable
-	@[ "${DUT}" ] || ( echo "Usage:    DUT=<module> make waves"; exit 1 )
+test.waves:  ## Run tests and open gtkwave of DUT variable
+	@[ "${DUT}" ] || ( echo "Usage:    DUT=<module> make test.waves"; exit 1 )
 	@$(call run_in_container, ./run_cocotb_tests.sh ${DUT} --waves)
+
+
+# waves:  ## Run gtkwave with last test result from DUT variable
+# 	@[ "${DUT}" ] || ( echo "Usage:    DUT=<module> make waves"; exit 1 )
+# 	@$(call run_in_container, ./run_cocotb_tests.sh ${DUT} --waves)
 
 
 flake8:  ## Run flake8 code quality check
@@ -51,8 +56,8 @@ verible:  ## Run verible-verilog-lint code quality check
 	@$(call run_in_container, verible-verilog-lint ${VHDL_FILES})
 
 
+
 quality: flake8 verible  ## Run all quality check
 
-
 .DEFAULT_GOAL := help
-.PHONY: help clean build-docker dockershell test flake8 verible quality
+.PHONY: help clean build.docker dockershell test.waves flake8 verible quality

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-cocotb==1.8.0
 flake8==6.0.0
+cocotb==1.8.0
+cocotbext-spi==0.3.2

--- a/rtl/spi_slave/spi_slave.v
+++ b/rtl/spi_slave/spi_slave.v
@@ -1,0 +1,213 @@
+`timescale 1us / 1ns
+
+module spi_slave #(
+    parameter CLK_RATE = 100000,
+    parameter DATA_LEN = 8
+) (
+    input                   clk,
+    input                   rst,
+    // axi stream to transmit
+    input [DATA_LEN-1:0]    tx_tdata,
+    input                   tx_tvalid,
+    output                  tx_tready,
+    // axi stream to receive
+    output [DATA_LEN-1:0]   rx_tdata,
+    output                  rx_tvalid,
+    input                   rx_tready,
+    // spi
+    output                  spi_miso,
+    input                   spi_mosi,
+    input                   spi_sclk,
+    input                   spi_cs_n
+);
+
+    // axi registers
+    reg [DATA_LEN-1:0] tx_tdata_d, tx_tdata_q;
+    reg tx_tvalid_d, tx_tvalid_q;
+    reg tx_tready_d, tx_tready_q;
+
+    reg [DATA_LEN-1:0] rx_tdata_d, rx_tdata_q;
+    reg rx_tvalid_d, rx_tvalid_q;
+    reg rx_tready_d, rx_tready_q;
+
+    // assign tx_tdata_d = tx_tdata;  // conviene registrarlo?
+    assign tx_tvalid_d = tx_tvalid;
+    assign tx_tready = tx_tready_q;
+
+    assign rx_tdata = rx_tdata_q;
+    assign rx_tvalid = rx_tvalid_q;
+    assign rx_tready_d = rx_tready;
+
+    always @(posedge clk) begin
+        if (rst) begin
+            tx_tdata_q <= '0;
+            tx_tvalid_q <= 0;
+            tx_tready_q <= 1;
+
+            rx_tdata_q <= '0;
+            rx_tvalid_q <= 0;
+            rx_tready_q <= 0;
+
+            current_state_axi_tx <= TX_IDLE;
+            current_state_axi_rx <= RX_IDLE;
+        end
+        else begin
+            tx_tdata_q <= tx_tdata_d;
+            tx_tvalid_q <= tx_tvalid_d;
+            tx_tready_q <= tx_tready_d;
+
+            rx_tdata_q <= rx_tdata_d;
+            rx_tvalid_q <= rx_tvalid_d;
+            rx_tready_q <= rx_tready_d;
+
+            current_state_axi_tx <= next_state_axi_tx;
+            current_state_axi_rx <= next_state_axi_rx;
+        end
+    end
+
+    // axi fsm
+    typedef enum {TX_IDLE, TX_PENDING, TX_WAITING, TX_TRANSMITTING} fsm_state_axi_tx;
+    fsm_state_axi_tx current_state_axi_tx = TX_IDLE;
+    fsm_state_axi_tx next_state_axi_tx    = TX_IDLE;
+
+    typedef enum {RX_IDLE, RX_RECEIVING, RX_READY} fsm_state_axi_rx;
+    fsm_state_axi_rx current_state_axi_rx = RX_IDLE;
+    fsm_state_axi_rx next_state_axi_rx    = RX_IDLE;
+    
+    always @(*) begin
+        next_state_spi = current_state_spi;
+
+        spi_tx_data_d = spi_tx_data_q;
+        spi_rx_data_d = spi_rx_data_q;
+        spi_counter_d = spi_counter_q;
+
+        case (current_state_spi)
+            SPI_IDLE: begin
+                if (~spi_cs_n_q) begin
+                    next_state_spi = SPI_RUNNING;
+                end
+            end
+            SPI_RUNNING: begin
+                if (spi_sclk_d & ~spi_sclk_q & spi_counter_q != '0) begin
+                    // rising edge
+                    spi_tx_data_d = {spi_tx_data_q[DATA_LEN-2:0], '0};
+                end
+                else if (~spi_sclk_d & spi_sclk_q) begin
+                    // falling edge
+                    spi_rx_data_d = {spi_rx_data_q[DATA_LEN-2:0], spi_mosi_q};
+                    spi_counter_d = spi_counter_q + 'd1;
+                end
+                else if (spi_counter_q == DATA_LEN) begin
+                    next_state_spi = SPI_IDLE;
+                    spi_counter_d = '0;
+                end
+            end
+            // default?
+        endcase
+
+        next_state_axi_tx = current_state_axi_tx;
+        tx_tdata_d = tx_tdata_q;
+        tx_tready_d = tx_tready_q;
+
+        case (current_state_axi_tx)
+            TX_IDLE: begin
+                if (tx_tvalid_q == 1) begin
+                    next_state_axi_tx = TX_PENDING;
+                    tx_tready_d = 0;
+                    tx_tdata_d = tx_tdata;
+                end
+            end
+            TX_PENDING: begin
+                if (current_state_spi == SPI_IDLE) begin
+                    next_state_axi_tx = TX_WAITING;
+                    spi_tx_data_d = tx_tdata_q;
+                end
+            end
+            TX_WAITING: begin
+                if (current_state_spi == SPI_RUNNING) begin
+                    next_state_axi_tx = TX_TRANSMITTING;
+                end
+            end
+            TX_TRANSMITTING: begin
+                if (current_state_spi == SPI_IDLE) begin
+                    next_state_axi_tx = TX_IDLE;
+                    tx_tready_d = 1;
+                end
+            end
+            // default?
+        endcase
+
+        next_state_axi_rx = current_state_axi_rx;
+        rx_tdata_d = rx_tdata_q;
+        rx_tvalid_d = rx_tvalid_q;
+
+        case (current_state_axi_rx)
+            RX_IDLE: begin
+                if (current_state_spi == SPI_RUNNING) begin
+                    next_state_axi_rx = RX_RECEIVING;
+                end
+            end
+            RX_RECEIVING: begin
+                if (current_state_spi == SPI_IDLE) begin
+                    next_state_axi_rx = RX_READY;
+                    rx_tdata_d = spi_rx_data_q;
+                    rx_tvalid_d = 1;
+                end
+            end
+            RX_READY: begin
+                if (rx_tready_q == 1) begin
+                    next_state_axi_rx = RX_IDLE;
+                    rx_tvalid_d = 0;
+                end
+            end
+            // default?
+        endcase
+    end
+
+    // spi registers
+    localparam DATA_COUNTER_LEN = $clog2(DATA_LEN);
+    reg [DATA_COUNTER_LEN:0] spi_counter_d, spi_counter_q;
+    
+    reg [DATA_LEN-1:0] spi_tx_data_d, spi_tx_data_q;
+    reg [DATA_LEN-1:0] spi_rx_data_d, spi_rx_data_q;
+
+    reg spi_sclk_d, spi_sclk_q;
+    reg spi_mosi_d, spi_mosi_q;
+    reg spi_cs_n_d, spi_cs_n_q;
+
+    assign spi_sclk_d = spi_sclk;
+    assign spi_miso = spi_tx_data_q[DATA_LEN-1];
+    assign spi_mosi_d = spi_mosi;
+    assign spi_cs_n_d = spi_cs_n;
+
+    always @(posedge clk) begin
+        if (rst) begin
+            spi_counter_q <= '0;
+            spi_tx_data_q <= '0;
+            spi_rx_data_q <= '0;
+
+            spi_sclk_q <= 0;
+            spi_mosi_q <= 0;
+            spi_cs_n_q <= 1;
+
+            current_state_spi <= SPI_IDLE;
+        end
+        else begin
+            spi_counter_q <= spi_counter_d;
+            spi_tx_data_q <= spi_tx_data_d;
+            spi_rx_data_q <= spi_rx_data_d;
+
+            spi_sclk_q <= spi_sclk_d;
+            spi_mosi_q <= spi_mosi_d;
+            spi_cs_n_q <= spi_cs_n_d;
+
+            current_state_spi <= next_state_spi;
+        end
+    end
+
+    // spi fsm
+    typedef enum {SPI_IDLE, SPI_RUNNING} fsm_state_spi;
+    fsm_state_spi current_state_spi = SPI_IDLE;
+    fsm_state_spi next_state_spi    = SPI_IDLE;
+
+endmodule

--- a/run_tests.py
+++ b/run_tests.py
@@ -120,7 +120,7 @@ def parse_args():
     p.add_argument('--dut', help='Run test for one DUT')
 
     dut = p.add_argument_group('dut')
-    dut.add_argument('-w', '--waves', action='store_true', help='Open waveforms for ')
+    dut.add_argument('-w', '--waves', action='store_true', help='Open waveforms')
 
     return p.parse_args()
 

--- a/tests/test_spi_slave.py
+++ b/tests/test_spi_slave.py
@@ -1,0 +1,93 @@
+import cocotb
+
+from cocotb.clock import Clock
+from cocotb.triggers import Timer, RisingEdge
+from cocotbext.spi import SpiMaster, SpiSignals, SpiConfig
+
+clock_period = 10  # us
+
+
+def get_spi_master(dut):
+    spi_signals = SpiSignals(
+        sclk=dut.spi_sclk,
+        mosi=dut.spi_mosi,
+        miso=dut.spi_miso,
+        cs=dut.spi_cs_n,
+    )
+
+    spi_config = SpiConfig(
+        word_width=8,  # number of bits in a SPI transaction
+        sclk_freq=10000,  # clock rate in Hz
+        cpol=False,  # clock idle polarity
+        cpha=True,  # clock phase (CPHA=True means data sampled on second edge)
+        msb_first=True,  # the order that bits are clocked onto the wire
+        data_output_idle=1,  # the idle value of the MOSI or MISO line
+        ignore_rx_value=None,  # MISO value that should be ignored when received
+    )
+
+    spi_master = SpiMaster(spi_signals, spi_config)
+
+    return spi_master
+
+
+def init_clock(dut):
+    clock = Clock(dut.clk, clock_period, units="us")
+    cocotb.fork(clock.start())
+
+
+async def init_spi(dut):
+    dut.rst.value = 1
+    dut.tx_tvalid.value = 0
+    dut.tx_tdata.value = 0
+    dut.rx_tready.value = 0
+    await Timer(3 * clock_period, 'us')
+    dut.rst.value = 0
+
+
+@cocotb.test()
+async def test_01_slave_receives(dut):
+    init_clock(dut)
+    await init_spi(dut)
+
+    data = 0x61
+    spi_master = get_spi_master(dut)
+    await spi_master.write([data])
+
+    assert dut.rx_tvalid.value == 1
+    assert dut.rx_tdata.value == data
+
+    dut.rx_tready.value = 1
+    await RisingEdge(dut.clk)
+    dut.rx_tready.value = 0
+    await RisingEdge(dut.clk)
+    # Review if we need this extra clock. It means that rx_tready is registered
+    await RisingEdge(dut.clk)
+
+    assert dut.rx_tvalid.value == 0
+
+
+@cocotb.test()
+async def test_02_slave_transmit(dut):
+    init_clock(dut)
+    await init_spi(dut)
+
+    data = 0x61
+
+    assert dut.tx_tready.value == 1
+
+    dut.tx_tdata.value = data
+    dut.tx_tvalid.value = 1
+    await RisingEdge(dut.clk)
+    await RisingEdge(dut.clk)
+    # Review if we need this extra clock. It means that rx_tready is registered
+    await RisingEdge(dut.clk)
+
+    assert dut.tx_tready.value == 0
+
+    spi_master = get_spi_master(dut)
+    await spi_master.write([0x10])
+    await spi_master.wait()
+    read_bytes = await spi_master.read()
+
+    assert int(read_bytes.hex(), 16) == 0x61
+    await Timer(3 * clock_period, 'us')


### PR DESCRIPTION
# Descripcion

Agrego core `spi_slave`.

## Implementacion

FSM 


Ejecución de tests mediante `run_test.py` usando `cocotb` runner con sources de `verilog`.

### Flujo de trabajo propuesto

Setup:

1. `make build` construye la imagen de docker (cada vez que se modifique el archivo `Dockerfile`, no es necesario si no hubo cambios)

Desarrollo del core y/o tests respetando la siguiente estructura:

```
rtl/<directory1>/<directory2>
└──  <module>.v
tests/
└── test_<module>.py
```

1. `make flake8` chequea estilo de codigo python (los tests)
2. `make verible` chequea estilo de codigo verilog
3. `make test` corre todos los tests y `DUT=<module> make test` solo corre los tests del archivo llamado `test_<module>.py`
4. `DUT=<module> make waves` corre tests de un modulo y abre `gtkwave` con el waveform de salida

> Cada paso puede ejecutarse de forma manual dentro de un container que use la imagen de docker. Para ello el target `make dockershell` ejecuta `bash` en modo interactivo.

## Requisitos

- [docker](https://docs.docker.com/engine/install/) instalado

## Posibles problemas

Si `make waves` devuelve error al tratar de abrir `gtkwave` puede deberse a un problema de conexion a `xhost`.

## Referencias

- [cocotb](https://docs.cocotb.org/en/stable/install.html)
- [flake8](https://flake8.pycqa.org/en/latest/)
- [Makefile help](https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html)

# Proximos pasos

Pueden realizarse cambios en la estructura del proyecto como asi tambien en la forma de ejecutar tests.