### PR TITLE
Feat: add verilog uart (untested)

### DIFF
--- a/rtl/uart/uart.v
+++ b/rtl/uart/uart.v
@@ -1,0 +1,67 @@
+module uart #(
+    parameter DIV_BITS = 10;
+) (
+    input i_clk,
+    input i_rst,
+
+    input [DIV_BITS-1:0] i_div,
+
+    input i_rxd,
+    output o_txd,
+
+    output [8-1:0] o_data,
+    output o_valid,
+    input i_ready,
+
+    input [8-1:0] i_data,
+    input i_valid,
+    output o_ready,
+
+    output o_rxerr
+
+);
+
+wire w_rxsync;
+
+wire w_txpulse;
+wire w_rxpulse;
+
+uart_clkgen #(.DIV_BITS(DIV_BITS)) inst_clkgen (
+    .i_clk(i_clk),
+    .i_rst(i_rst),
+    .i_div(i_div),
+    .i_rxsync(w_rxsync),
+    .o_txpulse(w_txpulse),
+    .o_rxpulse(w_rxpulse)
+);
+
+uart_rx inst_rx (
+    .o_data(o_data),
+    .o_valid(o_valid),
+    .i_ready(i_ready),
+
+    .i_clk(i_clk),
+    .i_rst(i_rst),
+
+    .i_rxd(i_rxd),
+
+    .i_rxpulse(w_rxpulse),   
+    
+    .o_err(o_err),
+    .o_rxsync(w_rxsync)
+);
+
+uart_tx inst_tx (
+    .i_data(i_data),
+    .i_valid(i_valid),
+    .o_ready(o_ready),
+
+    .i_clk(i_clk),
+    .i_rst(i_rst),
+
+    .o_txd(o_txd),
+
+    .i_txpulse(w_txpulse)
+);
+    
+endmodule

--- a/rtl/uart/uart.v
+++ b/rtl/uart/uart.v
@@ -1,5 +1,5 @@
 module uart #(
-    parameter DIV_BITS = 10;
+    parameter DIV_BITS = 10
 ) (
     input i_clk,
     input i_rst,

--- a/rtl/uart/uart_clkgen.v
+++ b/rtl/uart/uart_clkgen.v
@@ -8,8 +8,8 @@ module uart_clkgen #(
 
     input i_rxsync,
     
-    output o_txpulse,
-    output o_rxpulse
+    output reg o_txpulse,
+    output reg o_rxpulse
 );
 
 reg [DIV_BITS-1:0] r_txclk;

--- a/rtl/uart/uart_clkgen.v
+++ b/rtl/uart/uart_clkgen.v
@@ -1,0 +1,77 @@
+module uart_clkgen #(
+    parameter DIV_BITS = 10
+) (
+    input i_clk,
+    input i_rst,
+
+    input [DIV_BITS-1:0] i_div,
+
+    input i_rxsync,
+    
+    output o_txpulse,
+    output o_rxpulse
+);
+
+reg [DIV_BITS-1:0] r_txclk;
+reg [DIV_BITS-1:0] r_rxclk;
+
+//sobresampleo 16x (por la cantidad de bits)
+reg [4-1:0] r_txcntr;
+reg [4-1:0] r_rxcntr;
+
+reg [DIV_BITS-1:0] r_div;
+    
+always @(posedge i_rst or posedge i_clk) begin
+    
+    if (i_rst == 1'b1) begin
+        
+       r_div <= 'b0;
+       r_txclk <= 'b0;
+       r_rxclk <= 'b0;
+       r_txcntr <= 'b0;
+       r_rxcntr <= 'b0;
+
+    end else begin
+        
+        r_div <= i_div;
+        o_rxpulse <= 1'b0;
+        o_txpulse <= 1'b0;
+
+        if (i_rxsync == 1'b1) begin
+            r_rxcntr <= 'b0;
+            r_rxclk <= 'b0;
+        end
+
+        if (r_div != 'b0) begin
+
+            r_txclk <= r_txclk + 1;
+            r_rxclk <= r_rxclk + 1;
+
+            if (r_txclk >= r_div) begin
+                r_txclk <= 'b0;
+                
+                if (r_txcntr >= 4'd15)
+                    o_txpulse <= 1'b1;
+
+                r_txcntr <= r_txcntr + 1;
+
+            end
+
+            if (r_rxclk >= r_div) begin
+                r_rxclk <= 'b0;
+                
+                if (r_rxcntr >= 4'd5 && r_rxcntr <= 4'd7)
+                    o_rxpulse <= 1'b1;
+
+                r_rxcntr <= r_rxcntr + 1;
+
+            end
+
+        end
+
+    end
+
+end
+
+
+endmodule

--- a/rtl/uart/uart_rx.v
+++ b/rtl/uart/uart_rx.v
@@ -1,6 +1,6 @@
 module uart_rx (
     //stream interface
-    output [8-1:0] o_data,
+    output reg [8-1:0] o_data,
     output o_valid,
     input i_ready,
 
@@ -11,8 +11,8 @@ module uart_rx (
 
     input i_rxpulse,
     
-    output o_err,
-    output o_rxsync
+    output reg o_err,
+    output reg o_rxsync
 );
 
 localparam STATE_BITS = 2;
@@ -89,7 +89,7 @@ always @(posedge i_rst or posedge i_clk) begin
                         r_actstate <= S_RXRECV;
                         o_rxsync <= 1'b1;
                         r_samplecntr <= 2'd2;
-                        r_bitcntr <= 3'b7;
+                        r_bitcntr <= 3'd7;
                         r_samplereg <= 'b0;
                         r_valid <= 1'b0;
                     end
@@ -109,7 +109,7 @@ always @(posedge i_rst or posedge i_clk) begin
 
                 S_RXEND : begin
 
-                    if (r_safebit = 1'b1) begin
+                    if (r_safebit == 1'b1) begin
                         r_actstate <= S_IDLE;
                         o_data <= r_rxdata;
                         r_valid <= 1'b1;
@@ -119,11 +119,12 @@ always @(posedge i_rst or posedge i_clk) begin
 
                 end
 
-                S_RXERR,
-                default : begin
+                S_RXERR : begin
                     r_actstate <= S_IDLE;
                     o_err <= 1'b1;
                 end
+
+                default : r_actstate <= S_IDLE;
 
             endcase
 

--- a/rtl/uart/uart_rx.v
+++ b/rtl/uart/uart_rx.v
@@ -1,0 +1,136 @@
+module uart_rx (
+    //stream interface
+    output [8-1:0] o_data,
+    output o_valid,
+    input i_ready,
+
+    //control signals
+    input i_clk,
+    input i_rxd,
+    input i_rst,
+
+    input i_rxpulse,
+    
+    output o_err,
+    output o_rxsync
+);
+
+localparam STATE_BITS = 2;
+localparam  S_IDLE =        'd0,
+            S_RXRECV =      'd1,
+            S_RXEND =       'd2,
+            S_RXERR =       'd3
+;
+
+reg [2-1:0] r_samplecntr;
+reg [3-1:0] r_bitcntr;
+reg r_bitsignal;
+reg r_safebit;
+reg r_valid;
+
+reg r_actstate;
+reg [8-1:0] r_rxdata;
+reg [3-1:0] r_samplereg;
+
+reg [2-1:0] r_rxdmeta;
+
+reg r_ready;
+
+assign o_valid = r_valid;
+
+always @(posedge i_rst or posedge i_clk) begin
+
+    if (i_rst == 1'b1) begin
+        
+        r_valid <= 'b0;
+        r_actstate <= S_IDLE;
+        r_samplecntr <= 2'b0;
+
+    end else begin
+
+        r_rxdmeta = r_rxdmeta << 1;
+        r_rxdmeta[0] <= i_rxd;
+
+        r_bitsignal <= 1'b0;
+        o_rxsync <= 1'b0;
+
+        if (i_rxpulse == 1'b1) begin
+            
+            r_samplereg[r_samplecntr] <= r_rxdmeta[1];
+            
+            if (r_samplecntr == 2'b0) begin
+                
+                case (r_samplereg)
+                    
+                    3'd0,
+                    3'd1,
+                    3'd2,
+                    3'd4 : r_safebit <= 1'b0;
+
+                    default : r_safebit <= 1'b1;
+
+                endcase
+
+                r_bitsignal <= 1'b1;
+
+            end
+
+            r_samplecntr <= r_samplecntr - 1;
+        end
+
+        if (r_bitsignal == 1'b1) begin
+
+            o_err <= 1'b0;
+
+            case (r_actstate)
+
+                S_IDLE : begin
+                    if (r_safebit == 1'b0) begin
+                        r_actstate <= S_RXRECV;
+                        o_rxsync <= 1'b1;
+                        r_samplecntr <= 2'd2;
+                        r_bitcntr <= 3'b7;
+                        r_samplereg <= 'b0;
+                        r_valid <= 1'b0;
+                    end
+                end
+
+                S_RXRECV : begin
+
+                    r_rxdata[r_bitcntr] <= r_safebit;
+
+                    if (r_bitcntr == 3'b0) begin
+                        r_actstate <= S_RXEND;
+                    end
+
+                    r_bitcntr <= r_bitcntr - 1;
+
+                end
+
+                S_RXEND : begin
+
+                    if (r_safebit = 1'b1) begin
+                        r_actstate <= S_IDLE;
+                        o_data <= r_rxdata;
+                        r_valid <= 1'b1;
+                    end else begin
+                        r_actstate <= S_RXERR;
+                    end
+
+                end
+
+                S_RXERR,
+                default : begin
+                    r_actstate <= S_IDLE;
+                    o_err <= 1'b1;
+                end
+
+            endcase
+
+        end
+
+    end
+
+end
+    
+endmodule

--- a/rtl/uart/uart_tx.v
+++ b/rtl/uart/uart_tx.v
@@ -3,14 +3,14 @@ module uart_tx (
     // input stream
     input [8-1:0] i_data,
     input i_valid,
-    output o_ready,
+    output reg o_ready,
 
     // control signal
     input i_clk,
     input i_rst,
 
     input i_txpulse,
-    output o_txd
+    output reg o_txd
 
 );
 

--- a/rtl/uart/uart_tx.v
+++ b/rtl/uart/uart_tx.v
@@ -1,0 +1,104 @@
+module uart_tx (
+    
+    // input stream
+    input [8-1:0] i_data,
+    input i_valid,
+    output o_ready,
+
+    // control signal
+    input i_clk,
+    input i_rst,
+
+    input i_txpulse,
+    output o_txd
+
+);
+
+localparam STATE_BITS = 3;
+localparam  S_IDLE =        'd0,
+            S_SYNC =        'd1,
+            S_TXSTART =     'd2,
+            S_TXSEND =      'd3,
+            S_TXSTOP =      'd4
+;
+
+wire w_baudclk;
+wire w_intrst;
+
+reg [3-1:0] r_bitcnt;
+reg [3-1:0] r_nextcnt;
+reg [8-1:0] r_txdata;
+reg [STATE_BITS-1:0] r_actstate;
+
+assign w_intrst = i_rst;
+
+always @(posedge i_clk or posedge w_intrst) begin
+    
+    if (w_intrst == 1'b1) begin
+        
+        r_actstate <= S_IDLE;
+        r_bitcnt <= 'b0;
+        r_txdata <= 'b0;
+        o_ready <= 'b0;
+    
+    end else begin
+
+        o_txd <= 1'b1;
+        o_ready <= 1'b0;
+
+        case (r_actstate)
+
+            S_IDLE: begin
+                o_ready <= 1'b1;
+                r_txdata <= 'b0;
+                if (i_valid == 1'b1) begin
+                    r_txdata <= i_data;
+                    r_actstate <= S_SYNC;
+                    o_ready <= 1'b0;
+                end
+            end
+
+            S_SYNC: begin
+                if (i_txpulse == 1'b1) begin
+                    r_bitcnt <= 8'd7;
+                    r_actstate <= S_TXSTART;
+                end
+            end
+
+            S_TXSTART: begin
+                o_txd <= 1'b0;
+                if (i_txpulse == 1'b1) begin
+                    r_actstate <= S_TXSEND;
+                end
+            end
+
+            S_TXSEND: begin
+                
+                o_txd <= r_txdata[r_bitcnt];
+                if (i_txpulse == 1'b1) begin
+                    if (r_bitcnt > 8'd0) begin
+                        r_bitcnt <= r_bitcnt - 1;
+                    end else begin
+                        r_actstate <= S_TXSTOP;
+                    end
+                end
+
+            end
+
+            S_TXSTOP: begin
+                if (i_txpulse == 1'b1) begin
+                    r_actstate <= S_IDLE;
+                end
+            end
+
+            default: begin
+                r_actstate <= S_IDLE;
+            end
+
+        endcase 
+
+    end
+
+end
+    
+endmodule


### PR DESCRIPTION
Agrego branch para mergear la uart pasada a verilog.

Actualmente faltan las siguientes cosas:
- Verificar la síntesis de cada uno de los elementos
- Simular cada uno de los elementos
- Escribir y realizar tests en cocotb (deberia hacerse rapido, ya los tests estan escritos para la otra uart y reutilize los nombres de las señales).
- Enlazar todos los modulos en un uart.v
- Probar en hardware
- Probar en hardware con la fifo